### PR TITLE
Improve documentation of post_splitter.py utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # stackoverflow-posts-preprocessing
+
 Scripts for pre-processing Stack Overflow Posts.xml from https://archive.org/details/stackexchange
 
-# Installing Dependencies
+## Installing Dependencies
+
 The scripts depend on **nltk** for NLP tools and **xmltodict** to process the xml files. To install the dependencies, run the command:
 ```
 pip install nltk xmltodict
@@ -22,13 +24,26 @@ A window should open with the available packages. Install the following packages
 - averaged-perceptron-tagger
 - maxent-ne-chunker
 
-# File Splitting
+## File Splitting
+
 Because the Stack Overflow Posts.xml file holds over 70GB of data, it's advised to export only the posts you desire to analyze before running any sort of post-processing. The `post_splitter.py` script does that, extracting posts with a creation date matching the desired years, and saving all posts of each year to an individual xml file.
 
-# Pre-Processing
+You can run the file splitter utility by issuing the following command:
+```bash
+python post_splitter.py --posts_xml_path <path_to_Posts_xml_file> --first_tag <first_tag> --second_tag <second_tag> --out_dir <path_to_output_files_dir>
+```
+
+More information about the arguments can be obtained by running
+```bash
+python post_splitter.py -h
+```
+
+## Pre-Processing
+
 The `xml_to_json.py` script is responsible for taking the xml files, generating a dictionary containing all the questions with the answers for each question as an array property of the question object, and saving it to a JSON file. This is done because JSON is a better file format than XML to load as a python object. For the sake of optimization, the `preprocessing.py` script is called when the dictionary is being generated, so the posts title and body can be pre-processed while the dictionary is being generated.
 
-# Processing
+## Processing
+
 The following scripts are used for processing the posts:
 
 - `post_stats.py` - receives a pre-processed posts file and returns an object with statistical data.

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -2,8 +2,6 @@ from xml_to_json import process_posts
 from preprocessing import preprocess_text
 from post_stats import generate_stats
 from post_freqdist import generate_freqdist
-from post_splitter import split_posts
-from post_splitter_nineteen import split_posts_nineteen
 from post_sentiment_analysis import sentiment_analysis
 import json
 import multiprocessing

--- a/scripts/post_splitter.py
+++ b/scripts/post_splitter.py
@@ -1,3 +1,5 @@
+from argparse import ArgumentParser
+from os import path
 import json
 import xmltodict
 from pathlib import Path
@@ -40,7 +42,7 @@ def split_posts(posts_xml_path, output_xml_paths, filtertag1 = None, filtertag2 
                                         posts_2017_xml.write(line)
                                     elif year == '2018':
                                         posts_2018_xml.write(line)
-                                    
+
                                 processed_lines = processed_lines + 1
 
                                 if timer() - interval > 300:
@@ -48,3 +50,45 @@ def split_posts(posts_xml_path, output_xml_paths, filtertag1 = None, filtertag2 
                                     interval = timer()
 
     print(f"File splitting by year finished in {round(timer() - start, 2)} seconds.")
+
+if __name__ == "__main__":
+    parser = ArgumentParser("""
+
+This script filters the Stackoverflow Posts.xml file, generating output files
+for the years 2015-2018 that contain posts related to two tags that are passed
+as aguments.
+
+It will output the files <out_dir>/<first_tag>_<second_tag>_<year>.xml, where
+<year> is one of the values 2015-2018, <out_dir> is the output directory passed
+as an argument, and <first_tag> and <second_tag> are the tags used for filtering
+which are also passed as arguments.
+
+python post_splitter.py
+""")
+    parser.add_argument(
+        "--posts_xml_path", default="./Posts.xml", type=str,
+        help="Path to the Posts.xml file containing the Stackoverflow database file."
+    )
+    parser.add_argument(
+        "--first_tag", default=None, type=str,
+        help="The first tag to be filtered. (Optional)"
+    )
+    parser.add_argument(
+        "--second_tag", default=None, type=str,
+        help="The second tag to be filtered. (Optional)"
+    )
+    parser.add_argument(
+        "--out_dir", default="./", type=str,
+        help="The output directory. Note: It must already exist."
+    )
+
+    args = parser.parse_args()
+    files_root = args.out_dir
+    posts_path = args.posts_xml_path
+    tag_1 = args.first_tag
+    tag_2 = args.second_tag
+    output_xml_paths = {
+        year: path.join(files_root, f"{tag_1}_{tag_2}_{year}.xml") \
+            for year in list(map(str, range(2015, 2019)))
+    }
+    split_posts(posts_path, output_xml_paths, tag_1, tag_2)


### PR DESCRIPTION
This pull request adds documentation on how to properly use the `post_splitter.py` utility.
Files modified:
* `scripts/post_splitter.py` - Added documentation using Python's `argparse` module;
* `README.md` - Added information about the `post_splitter.py` usage and fixed some MD syntax issues;
* `scripts/main.py` - Removed unused imports.
